### PR TITLE
Allow PHPUnit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.php_cs
 /.php_cs.cache
+/.phpunit.result.cache
 /composer.lock
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "^5.5 || ^7.0",
-    "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0",
+    "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0 || ^8.0",
     "phpunitgoodpractices/polyfill": "^1.1"
   },
   "conflict": {

--- a/src/Constraint/IsIdenticalString.php
+++ b/src/Constraint/IsIdenticalString.php
@@ -13,6 +13,8 @@ namespace PhpCsFixer\PhpunitConstraintIsIdenticalString\Constraint;
 
 if (version_compare(\PHPUnit\Runner\Version::id(), '7.0.0') < 0) {
     class_alias(IsIdenticalStringForV5::class, IsIdenticalString::class);
-} else {
+} elseif (version_compare(\PHPUnit\Runner\Version::id(), '8.0.0') < 0) {
     class_alias(IsIdenticalStringForV7::class, IsIdenticalString::class);
+} else {
+    class_alias(IsIdenticalStringForV8::class, IsIdenticalString::class);
 }

--- a/src/Constraint/IsIdenticalStringForV8.php
+++ b/src/Constraint/IsIdenticalStringForV8.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer / PHPUnit Constraint IsIdenticalString.
+ *
+ * (c) Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\PhpunitConstraintIsIdenticalString\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsIdentical;
+use PHPUnit\Framework\ExpectationFailedException;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ */
+final class IsIdenticalStringForV8 extends Constraint
+{
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @var IsIdentical
+     */
+    private $isIdentical;
+
+    /**
+     * @param mixed $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+        $this->isIdentical = new IsIdentical($this->value);
+    }
+
+    public function evaluate($other, string $description = '', bool $returnResult = false)
+    {
+        try {
+            return $this->isIdentical->evaluate($other, $description, $returnResult);
+        } catch (ExpectationFailedException $exception) {
+            $message = $exception->getMessage();
+
+            $additionalFailureDescription = $this->additionalFailureDescription($other);
+
+            if ($additionalFailureDescription) {
+                $message .= "\n".$additionalFailureDescription;
+            }
+
+            throw new ExpectationFailedException(
+                $message,
+                $exception->getComparisonFailure(),
+                $exception
+            );
+        }
+    }
+
+    public function toString(): string
+    {
+        return $this->isIdentical->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        if (
+            $other === $this->value
+            || preg_replace('/(\r\n|\n\r|\r)/', "\n", $other) !== preg_replace('/(\r\n|\n\r|\r)/', "\n", $this->value)
+        ) {
+            return '';
+        }
+
+        return ' #Warning: Strings contain different line endings! Debug using remapping ["\r" => "R", "\n" => "N", "\t" => "T"]:'
+            ."\n"
+            .' -'.str_replace(["\r", "\n", "\t"], ['R', 'N', 'T'], $other)
+            ."\n"
+            .' +'.str_replace(["\r", "\n", "\t"], ['R', 'N', 'T'], $this->value);
+    }
+}


### PR DESCRIPTION
In PHPUnit 8 class `PHPUnit\Framework\Constraint\IsIdentical` become `final` so I don't know how we can make better than this.